### PR TITLE
Cachedb port from ENV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+cachedb

--- a/router.go
+++ b/router.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"net/http"
+	"os"
 	"strconv"
 
 	"github.com/go-chi/chi"
@@ -12,6 +13,8 @@ import (
 // constants
 const (
 	MalformedParams = "MALFORMED_PARAMS"
+
+	DefaultPort = "9898"
 )
 
 // RouterConfig holds router config
@@ -24,6 +27,18 @@ type RouterConfig struct {
 type Response struct {
 	Data  string `json:"data"`
 	Error bool   `json:"error"`
+}
+
+var (
+	serverPort string
+)
+
+func setConfigVars() {
+	if len(os.Getenv("CACHEDB_PORT")) == 0 {
+		serverPort = DefaultPort
+	} else {
+		serverPort = os.Getenv("CACHEDB_PORT")
+	}
 }
 
 func (R *RouterConfig) initializeRouter(CacheRef GlobalCacheRef) {
@@ -104,5 +119,13 @@ func (R *RouterConfig) registerRoutes() {
 		respondWithJSON(w, r, res)
 
 	})
-	log.Fatal(http.ListenAndServe(":9898", r))
+
+	setConfigVars()
+	log.Printf("Using port: %v", serverPort)
+	srv := &http.Server{
+		Addr:    ":" + serverPort,
+		Handler: r,
+	}
+
+	log.Fatal(srv.ListenAndServe())
 }


### PR DESCRIPTION
Features:

- Added executable file cachedb into gitignore list
- Added ability for user to set port using env variables, if he didn't set, the default port would be used